### PR TITLE
Bugfix/66512

### DIFF
--- a/config/appsettings.json
+++ b/config/appsettings.json
@@ -371,7 +371,7 @@
     "api": "api/2.0",
     "alias": {
       "min": 3,
-      "max": 100
+      "max": 63
     },
     "api-system": "",
     "api-cache": "",


### PR DESCRIPTION
fix Bug 66512

A subdomain can be up to 255 characters long, but if you have multiple levels in your subdomain, each level can only be 63 characters long.