### PR TITLE
Fix ubuntu24 install: dotnet-8.0

### DIFF
--- a/install/OneClickInstall/install-Debian/install-preq.sh
+++ b/install/OneClickInstall/install-Debian/install-preq.sh
@@ -48,9 +48,11 @@ NODE_VERSION="18"
 curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
 
 #add dotnet repo
-curl https://packages.microsoft.com/config/$DIST/$REV/packages-microsoft-prod.deb -O
-echo -e "Package: *\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 1002" | tee /etc/apt/preferences.d/99microsoft-prod.pref
-dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb
+if [[ "$DISTRIB_CODENAME" != noble ]]; then
+	curl https://packages.microsoft.com/config/$DIST/$REV/packages-microsoft-prod.deb -O
+	echo -e "Package: *\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 1002" | tee /etc/apt/preferences.d/99microsoft-prod.pref
+	dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb
+fi
 
 MYSQL_REPO_VERSION="$(curl https://repo.mysql.com | grep -oP 'mysql-apt-config_\K.*' | grep -o '^[^_]*' | sort --version-sort --field-separator=. | tail -n1)"
 MYSQL_PACKAGE_NAME="mysql-apt-config_${MYSQL_REPO_VERSION}_all.deb"


### PR DESCRIPTION
For 24.04 onwards Microsoft will no longer be providing .NET packages, instead Canonical's dotnet packages will be used. Thus, we need to remove microsoft repo installation on Ubuntu 24.04 noble