### PR TITLE
Add openssl dependency for packages

### DIFF
--- a/install/deb/debian/control
+++ b/install/deb/debian/control
@@ -11,7 +11,7 @@ Multi-Arch: foreign
 Package: {{product}}
 Architecture: all
 Multi-Arch: foreign
-Depends: debconf,
+Depends: debconf, openssl,
          ${misc:Depends}, ${shlibs:Depends},
          {{product}}-api (= {{package_header_tag_version}}),
          {{product}}-api-system (= {{package_header_tag_version}}),

--- a/install/rpm/SPECS/product.spec
+++ b/install/rpm/SPECS/product.spec
@@ -53,6 +53,7 @@ Requires:       %name-socket = %version-%release
 Requires:       %name-ssoauth = %version-%release
 Requires:       %name-studio = %version-%release
 Requires:       %name-studio-notify = %version-%release
+Requires:       openssl
 
 %description
 ONLYOFFICE DocSpace is a new way to collaborate on documents with teams, 


### PR DESCRIPTION
We use openssl in [product-configuration script](https://github.com/ONLYOFFICE/DocSpace-buildtools/blob/f5819363778cc79e7956c72cc7b4b1f7e39c8921/install/common/product-configuration#L733) to securely generate dashboards pass, so we need openssl to be installed. Otherwise, script will through an error -> exit 1